### PR TITLE
fix: adding missing AUTH_TYPE_KEY to JWT constant

### DIFF
--- a/packages/auth-common/src/components/constants.ts
+++ b/packages/auth-common/src/components/constants.ts
@@ -13,10 +13,13 @@ export const HEADERS = {
 
 export const JWT = {
 	ALG: "RS256",
+
 	USER_ID_KEY: "sub",
 	TOKEN_ID_KEY: "__raw",
 	NONCE_KEY: "_nonce",
 	USERNAME_KEY: "username",
+	AUTH_TYPE_KEY: "auth_type",
+
 	ISSUER: "gizmette.com",
 };
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added the missing `AUTH_TYPE_KEY` to the `JWT` constant in the `constants.ts` file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.ts</strong><dd><code>Add missing `AUTH_TYPE_KEY` to `JWT` constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auth-common/src/components/constants.ts

- Added `AUTH_TYPE_KEY` to the `JWT` constant.



</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/103/files#diff-bbc111987d4988b036dd57abd471d6a0ff4ed9cc03a43620af0289f9c26e69a3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

