### PR TITLE
feat: allowing AND or OR operations for isGranted

### DIFF
--- a/packages/auth-common/src/components/__tests__/isGranted.test.ts
+++ b/packages/auth-common/src/components/__tests__/isGranted.test.ts
@@ -102,4 +102,54 @@ describe("isGranted", () => {
 		});
 		expect(result).toBe(false);
 	});
+
+	it("should verify that 1 or another scope is allowed", async () => {
+		const mockPublicKey = {};
+		const mockJwtVerifyResult = {
+			payload: {
+				scopes: ["write"],
+			},
+			protectedHeader: "testHeader",
+		};
+		// @ts-expect-error
+		(importSPKI as vi.Mock).mockResolvedValue(mockPublicKey);
+		// @ts-expect-error
+		(jwtVerify as vi.Mock).mockResolvedValue(mockJwtVerifyResult);
+
+		const result = await isGranted(token, {
+			user: ["read"],
+			edit: ["write"],
+		});
+
+		expect(importSPKI).toHaveBeenCalledWith(JWT_PUBLIC_KEY, JWT.ALG);
+		expect(jwtVerify).toHaveBeenCalledWith(token, mockPublicKey, {
+			issuer: JWT.ISSUER,
+		});
+		expect(result).toBe(true);
+	});
+
+	it("should verify that 1 or another scope are not allowed", async () => {
+		const mockPublicKey = {};
+		const mockJwtVerifyResult = {
+			payload: {
+				scopes: ["write"],
+			},
+			protectedHeader: "testHeader",
+		};
+		// @ts-expect-error
+		(importSPKI as vi.Mock).mockResolvedValue(mockPublicKey);
+		// @ts-expect-error
+		(jwtVerify as vi.Mock).mockResolvedValue(mockJwtVerifyResult);
+
+		const result = await isGranted(token, {
+			user: ["read"],
+			admin: ["read", "write"],
+		});
+
+		expect(importSPKI).toHaveBeenCalledWith(JWT_PUBLIC_KEY, JWT.ALG);
+		expect(jwtVerify).toHaveBeenCalledWith(token, mockPublicKey, {
+			issuer: JWT.ISSUER,
+		});
+		expect(result).toBe(false);
+	});
 });

--- a/packages/auth-common/src/components/isGranted.ts
+++ b/packages/auth-common/src/components/isGranted.ts
@@ -1,15 +1,66 @@
 import { JWT } from "./constants";
 import { verifyAndExtractToken } from "./verifyToken";
 
+export type ScopesGrants =
+	| {
+			[key: string]: string[];
+	  }
+	| string[];
+
+/**
+ * Checks if the given token grants the required scopes.
+ *
+ * This function verifies the provided token and extracts its payload.
+ * It then checks if the token contains the required scopes. The scopes can be provided
+ * either as an array of strings or as a map of string arrays. When the scopes are provided
+ * as a map, the function checks if the token contains at least one of the scopes in each
+ * of the map's values (OR operation).
+ *
+ *
+ * @async
+ * @function isGranted
+ * @param {string} token - The token to be verified and checked for scopes.
+ * @param {ScopesGrants} scopes - The required scopes. This can be an array of strings
+ *  															representing the scopes or a map where the keys are strings
+ * 																and the values are arrays of strings representing the scopes.
+ * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating whether the
+ * 															token grants the required scopes.
+ *
+ * @example
+ * Example with an array of scopes (AND operation)
+ * const scopesArray = ["read", "write"];
+ * const res = isGranted(token, scopesArray);
+ * console.log(res); // true only if the token has both "read" and "write" scopes
+ *
+ * @example
+ * Example with a map of scopes (OR operation)
+ * const scopesMap = {
+ * 	"admin": ["read", "write"],
+ * 	"user": ["read"]
+ * };
+ * const res = isGranted(token, scopesMap);
+ * console.log(res); // true if the token has either "read" and "write" scopes or "read" scope
+ */
 export const isGranted = async (
 	token: string,
-	scopes: string[],
+	scopes: ScopesGrants,
 ): Promise<boolean> => {
 	const jwt = await verifyAndExtractToken(token);
 
 	if ((jwt && (jwt?.payload?.[JWT.SCOPES_KEY] as string[]))?.length) {
 		const tokenScopes = jwt.payload[JWT.SCOPES_KEY] as string[];
-		return scopes.every((scope) => tokenScopes.includes(scope));
+		if (Array.isArray(scopes)) {
+			return scopes.every((scope) => tokenScopes.includes(scope));
+		} else {
+			/**
+			 * This is a more complex case where we have a map of scopes
+			 * and we need to check if some of the scopes in the map are present
+			 * in the token.
+			 */
+			return Object.keys(scopes).some((key) =>
+				scopes[key].every((scope) => tokenScopes.includes(scope)),
+			);
+		}
 	}
 	return false;
 };

--- a/packages/auth-common/src/components/isGranted.ts
+++ b/packages/auth-common/src/components/isGranted.ts
@@ -47,20 +47,17 @@ export const isGranted = async (
 ): Promise<boolean> => {
 	const jwt = await verifyAndExtractToken(token);
 
-	if ((jwt && (jwt?.payload?.[JWT.SCOPES_KEY] as string[]))?.length) {
-		const tokenScopes = jwt.payload[JWT.SCOPES_KEY] as string[];
-		if (Array.isArray(scopes)) {
-			return scopes.every((scope) => tokenScopes.includes(scope));
-		} else {
-			/**
-			 * This is a more complex case where we have a map of scopes
-			 * and we need to check if some of the scopes in the map are present
-			 * in the token.
-			 */
-			return Object.keys(scopes).some((key) =>
-				scopes[key].every((scope) => tokenScopes.includes(scope)),
-			);
-		}
+	if (!jwt || !Array.isArray(jwt.payload?.[JWT.SCOPES_KEY])) {
+		return false;
 	}
-	return false;
+
+	const tokenScopes = jwt.payload[JWT.SCOPES_KEY] as string[];
+
+	if (Array.isArray(scopes)) {
+		return scopes.every((scope) => tokenScopes.includes(scope));
+	}
+
+	return Object.keys(scopes).some((key) =>
+		scopes[key].every((scope) => tokenScopes.includes(scope)),
+	);
 };


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the `isGranted` function to support both AND and OR operations for scope verification.
- Introduced a new type `ScopesGrants` to handle different formats of scope inputs.
- Updated the function documentation to include examples for both AND and OR operations.
- Added new test cases to verify the functionality of the OR operation in the `isGranted` function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>isGranted.test.ts</strong><dd><code>Add tests for OR operation in isGranted function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auth-common/src/components/__tests__/isGranted.test.ts

<li>Added tests for verifying OR operation in <code>isGranted</code> function.<br> <li> Included test cases for both allowed and not allowed scopes.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/127/files#diff-a6c691343d71a4cdf94d6b0b6c1a68e2a40ed526e1791cd6eda250b589f7947b">+50/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>isGranted.ts</strong><dd><code>Enhance isGranted function to support AND and OR operations</code></dd></summary>
<hr>

packages/auth-common/src/components/isGranted.ts

<li>Enhanced <code>isGranted</code> function to support both AND and OR operations.<br> <li> Updated function documentation with examples.<br> <li> Introduced <code>ScopesGrants</code> type to handle different scope formats.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/127/files#diff-5a74c9ce1311c03e40a9320ec991df9483651fab8b8df6668a30c0608ecd23d1">+53/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

