### PR TITLE
fix: drop support for old browsers

### DIFF
--- a/packages/auth-provider/vite.config.ts
+++ b/packages/auth-provider/vite.config.ts
@@ -38,7 +38,7 @@ try {
 export default defineConfig(() => {
 	return {
 		build: {
-			target: "esnext",
+			target: "es2020",
 			copyPublicDir: false,
 			lib: {
 				entry: resolve(__dirname, "src/components/index.ts"),
@@ -49,7 +49,6 @@ export default defineConfig(() => {
 				input: {
 					index: resolve(__dirname, "src/components/index.ts"),
 				},
-				treeshake: "smallest",
 				external: externalDependencies,
 				output: {
 					compact: true,

--- a/packages/auth-provider/vite.config.ts
+++ b/packages/auth-provider/vite.config.ts
@@ -1,5 +1,4 @@
 import { resolve } from "node:path";
-
 import fs from "fs-extra";
 import { defineConfig } from "vite";
 
@@ -39,6 +38,7 @@ try {
 export default defineConfig(() => {
 	return {
 		build: {
+			target: "esnext",
 			copyPublicDir: false,
 			lib: {
 				entry: resolve(__dirname, "src/components/index.ts"),


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Dropped support for old browsers by setting the build target to `esnext` in the Vite configuration file.
- Minor formatting changes in the Vite configuration file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vite.config.ts</strong><dd><code>Drop support for old browsers in Vite config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auth-provider/vite.config.ts

<li>Removed support for old browsers by setting the build target to <br><code>esnext</code>.<br> <li> Minor formatting changes.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/139/files#diff-9a88030d41697b58bca6e8ba97ad3a63de9604cf98bc556ab2f6c62f76acad4c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

