### PR TITLE
feat: default login type to code grant flow with PKCE

### DIFF
--- a/examples/code-flow/src/main.tsx
+++ b/examples/code-flow/src/main.tsx
@@ -1,4 +1,4 @@
-import { AUTH_TYPES, useAuth } from "@versini/auth-provider";
+import { useAuth } from "@versini/auth-provider";
 import { Button, Footer, Header, Main } from "@versini/ui-components";
 import { Flexgrid, FlexgridItem } from "@versini/ui-system";
 import { useEffect, useState } from "react";
@@ -20,17 +20,12 @@ export const App = ({ timeout }: { timeout: string }) => {
 		await login(
 			process.env.PUBLIC_TEST_USER as string,
 			process.env.PUBLIC_TEST_USER_PASSWORD as string,
-			AUTH_TYPES.CODE,
 		);
 	};
 
 	const handleInvalidLogin = async (e: { preventDefault: () => void }) => {
 		e.preventDefault();
-		await login(
-			process.env.PUBLIC_TEST_USER as string,
-			"invalid-password",
-			AUTH_TYPES.CODE,
-		);
+		await login(process.env.PUBLIC_TEST_USER as string, "invalid-password");
 	};
 
 	const handleValidAPICall = async (e: { preventDefault: () => void }) => {

--- a/packages/auth-provider/src/common/types.d.ts
+++ b/packages/auth-provider/src/common/types.d.ts
@@ -108,14 +108,14 @@ export type GetPreAuthCodeProps = {
 	code_challenge: string;
 };
 
-export type LoginType = (
+export type LoginResponse = (
 	username: string,
 	password: string,
 	type?: typeof AUTH_TYPES.CODE | typeof AUTH_TYPES.PASSKEY,
 ) => Promise<boolean>;
 
 export type AuthContextProps = {
-	login: LoginType;
+	login: LoginResponse;
 	logout: (e?: any) => void;
 	getAccessToken: () => Promise<string>;
 	getIdToken: () => string;

--- a/packages/auth-provider/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/auth-provider/src/components/AuthProvider/AuthProvider.tsx
@@ -24,7 +24,7 @@ import {
 	LOGOUT_SESSION,
 } from "../../common/constants";
 import { SERVICE_TYPES, graphQLCall } from "../../common/services";
-import type { AuthProviderProps, LoginType } from "../../common/types";
+import type { AuthProviderProps, LoginResponse } from "../../common/types";
 import {
 	authenticateUser,
 	emptyState,
@@ -128,15 +128,11 @@ export const AuthProvider = ({
 	 * This effect is responsible to set the fingerprintRef value when the
 	 * component is first loaded.
 	 */
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: logger is stable
 	useEffect(() => {
 		(async () => {
-			logger("useEffect: setting the fingerprint");
 			fingerprintRef.current = await getCustomFingerprint();
 		})();
 		return () => {
-			logger("useEffect: cleaning up the fingerprint");
 			fingerprintRef.current = "";
 		};
 	}, []);
@@ -186,7 +182,11 @@ export const AuthProvider = ({
 		};
 	}, [state.isLoading, idToken, invalidateAndLogout, logger]);
 
-	const login: LoginType = async (username, password, type) => {
+	const login: LoginResponse = async (
+		username,
+		password,
+		type = AUTH_TYPES.CODE,
+	) => {
 		const _nonce = uuidv4();
 		setNonce(_nonce);
 		dispatch({ type: ACTION_TYPE_LOADING, payload: { isLoading: true } });


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Set the default login type to `AUTH_TYPES.CODE` in the `AuthProvider` component.
- Updated the example application to use the default login type.
- Renamed `LoginType` to `LoginResponse` for better clarity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tsx</strong><dd><code>Default login type to code grant flow in example app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/code-flow/src/main.tsx

<li>Removed <code>AUTH_TYPES</code> import.<br> <li> Updated <code>login</code> function calls to use default <code>AUTH_TYPES.CODE</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/142/files#diff-d946e5fda3aa9a46fe5c70259c7f0adab8e8aa39a035f3f1fc49ebe1f08545f5">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.d.ts</strong><dd><code>Update login type definition to use default code grant flow</code></dd></summary>
<hr>

packages/auth-provider/src/common/types.d.ts

<li>Renamed <code>LoginType</code> to <code>LoginResponse</code>.<br> <li> Updated <code>login</code> type definition to use default <code>AUTH_TYPES.CODE</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/142/files#diff-dfb0d9d61ba1e66a907637e2da7b3b59715b065112682a7a818a4cdee558e366">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AuthProvider.tsx</strong><dd><code>Set default login type to code grant flow in AuthProvider</code></dd></summary>
<hr>

packages/auth-provider/src/components/AuthProvider/AuthProvider.tsx

<li>Renamed <code>LoginType</code> to <code>LoginResponse</code>.<br> <li> Set default login type to <code>AUTH_TYPES.CODE</code> in <code>AuthProvider</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/142/files#diff-54c3ec56369aa221bd0b1e0f69b89160959ff3769d8f1ce99df60798fc0be1a0">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

