### PR TITLE
fix: adding missing client id (audience) key

### DIFF
--- a/packages/auth-common/src/components/constants.ts
+++ b/packages/auth-common/src/components/constants.ts
@@ -26,6 +26,7 @@ export const JWT = {
 	EXPIRES_AT_KEY: "exp",
 	CREATED_AT_KEY: "iat",
 	SCOPES_KEY: "scopes",
+	CLIENT_ID_KEY: "aud",
 
 	ISSUER: "gizmette.com",
 };


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added the missing `CLIENT_ID_KEY` (audience) to the JWT constants in the `constants.ts` file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.ts</strong><dd><code>Add missing `CLIENT_ID_KEY` to JWT constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auth-common/src/components/constants.ts

- Added `CLIENT_ID_KEY` with value `aud` to JWT constants.



</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/154/files#diff-bbc111987d4988b036dd57abd471d6a0ff4ed9cc03a43620af0289f9c26e69a3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

