### PR TITLE
fix: logout accepts idToken for a more resilient process

### DIFF
--- a/packages/auth-provider/src/common/types.d.ts
+++ b/packages/auth-provider/src/common/types.d.ts
@@ -148,6 +148,7 @@ export type LogoutProps = {
 	userId: string;
 	clientId: string;
 	domain: string;
+	idToken?: string;
 };
 export type LogoutResponse = GenericResponse;
 

--- a/packages/auth-provider/src/common/utilities.ts
+++ b/packages/auth-provider/src/common/utilities.ts
@@ -68,6 +68,7 @@ export const logoutUser = async ({
 	userId,
 	clientId,
 	domain,
+	idToken = "",
 }: LogoutProps): Promise<LogoutResponse> => {
 	try {
 		const response = await restCall({
@@ -76,6 +77,7 @@ export const logoutUser = async ({
 			params: {
 				userId,
 				domain,
+				idToken,
 			},
 		});
 		return {

--- a/packages/auth-provider/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/auth-provider/src/components/AuthProvider/AuthProvider.tsx
@@ -146,6 +146,7 @@ export const AuthProvider = ({
 				userId,
 				clientId,
 				domain,
+				idToken,
 			});
 			removeStateAndLocalStorage(message || EXPIRED_SESSION);
 		},


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Enhanced the logout process by adding an optional `idToken` parameter to the `LogoutProps` type.
- Updated the `logoutUser` function to accept and utilize the `idToken` parameter for a more resilient logout process.
- Modified the `AuthProvider` component to pass the `idToken` to the `logoutUser` function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.d.ts</strong><dd><code>Add optional `idToken` to `LogoutProps` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auth-provider/src/common/types.d.ts

- Added optional `idToken` property to `LogoutProps` type.



</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/171/files#diff-dfb0d9d61ba1e66a907637e2da7b3b59715b065112682a7a818a4cdee558e366">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utilities.ts</strong><dd><code>Enhance `logoutUser` function with `idToken` parameter</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auth-provider/src/common/utilities.ts

<li>Added <code>idToken</code> parameter to <code>logoutUser</code> function.<br> <li> Updated <code>restCall</code> parameters to include <code>idToken</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/171/files#diff-99665bb86d24e186df31c3993f1c95a668378b6d735e25f66d4a0cd01fc5a5e9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AuthProvider.tsx</strong><dd><code>Pass `idToken` in `AuthProvider` logout call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auth-provider/src/components/AuthProvider/AuthProvider.tsx

- Passed `idToken` to `logoutUser` function in `AuthProvider`.



</details>


  </td>
  <td><a href="https://github.com/aversini/auth-client/pull/171/files#diff-54c3ec56369aa221bd0b1e0f69b89160959ff3769d8f1ce99df60798fc0be1a0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

